### PR TITLE
Fix tooltip positioning to fix #2

### DIFF
--- a/src/components/lint-error-tooltip.ts
+++ b/src/components/lint-error-tooltip.ts
@@ -47,8 +47,12 @@ export class LintErrorTooltip extends Component {
 
     this.#tooltip.style.top = `${y}px`;
 
-    const wouldOverflow = x + WIDTH + 2 * MARGIN > document.body.clientWidth;
-    this.#tooltip.style.left = wouldOverflow ? "0" : `${MARGIN}px`;
+    {
+      const availableWidth = document.body.clientWidth - 2 * MARGIN;
+      const rightOverflow = Math.max(x + WIDTH - (availableWidth + MARGIN), 0);
+      this.#tooltip.style.left = `${Math.max(x - rightOverflow, MARGIN)}px`;
+      this.#tooltip.style.maxWidth = `${availableWidth}px`;
+    }
 
     this.#tooltip.removeAttribute("hidden");
   }
@@ -79,8 +83,6 @@ export class LintErrorTooltip extends Component {
     element.style.boxSizing = "border-box";
     element.style.position = "absolute";
     element.style.width = `${WIDTH}px`;
-    element.style.margin = `${MARGIN}px`;
-    element.style.maxWidth = `calc(100vw - ${MARGIN * 2}px)`;
     element.style.display = "flex";
     element.style.flexDirection = "column";
     element.style.gap = "8px";


### PR DESCRIPTION
<img width="432" alt="screenshot of correctly positioned tooltip left-aligned with the corresponding annotation" src="https://github.com/iansan5653/github-markdown-a11y-extension/assets/2294248/abb4ab65-392e-4da1-8ac4-93e6d538117d">
