### PR TITLE
Switch to new external `dom-input-range` package for rect calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "license": "MIT",
       "dependencies": {
         "@github/markdownlint-github": "^0.4.1",
-        "markdownlint": "^0.31.1",
-        "textarea-range": "^0.0.1"
+        "dom-input-range": "^0.0.6",
+        "markdownlint": "^0.31.1"
       },
       "devDependencies": {
         "@babel/core": "^7.21.8",
@@ -3891,6 +3891,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-input-range": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-0.0.6.tgz",
+      "integrity": "sha512-yPnf+wyOOlHkXzpxH3PkgTi9C0vPso7KO/LUuYFlrWKi845SZED98qDpuB2nvEdmek0s8MXdDcjfWZ1bQBMzlw=="
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -8073,11 +8078,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/textarea-range": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/textarea-range/-/textarea-range-0.0.1.tgz",
-      "integrity": "sha512-UlIdRcAhVXfx9Udm5kKKr5PKC98ux0tqwRLfzIt34IsQeXfj3j6lF3wXSUNE6ZqpqZ31hibMAJC95qv/4V4ZSQ=="
-    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -11892,6 +11892,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-input-range": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-0.0.6.tgz",
+      "integrity": "sha512-yPnf+wyOOlHkXzpxH3PkgTi9C0vPso7KO/LUuYFlrWKi845SZED98qDpuB2nvEdmek0s8MXdDcjfWZ1bQBMzlw=="
+    },
     "dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -14973,11 +14978,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "textarea-range": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/textarea-range/-/textarea-range-0.0.1.tgz",
-      "integrity": "sha512-UlIdRcAhVXfx9Udm5kKKr5PKC98ux0tqwRLfzIt34IsQeXfj3j6lF3wXSUNE6ZqpqZ31hibMAJC95qv/4V4ZSQ=="
     },
     "thenify": {
       "version": "3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "license": "MIT",
       "dependencies": {
         "@github/markdownlint-github": "^0.4.1",
-        "markdownlint": "^0.31.1"
+        "markdownlint": "^0.31.1",
+        "textarea-range": "^0.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.21.8",
@@ -8072,6 +8073,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/textarea-range": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/textarea-range/-/textarea-range-0.0.1.tgz",
+      "integrity": "sha512-UlIdRcAhVXfx9Udm5kKKr5PKC98ux0tqwRLfzIt34IsQeXfj3j6lF3wXSUNE6ZqpqZ31hibMAJC95qv/4V4ZSQ=="
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -14967,6 +14973,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "textarea-range": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/textarea-range/-/textarea-range-0.0.1.tgz",
+      "integrity": "sha512-UlIdRcAhVXfx9Udm5kKKr5PKC98ux0tqwRLfzIt34IsQeXfj3j6lF3wXSUNE6ZqpqZ31hibMAJC95qv/4V4ZSQ=="
     },
     "thenify": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "license": "MIT",
   "dependencies": {
     "@github/markdownlint-github": "^0.4.1",
-    "markdownlint": "^0.31.1"
+    "markdownlint": "^0.31.1",
+    "textarea-range": "^0.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@github/markdownlint-github": "^0.4.1",
     "markdownlint": "^0.31.1",
-    "textarea-range": "^0.0.1"
+    "dom-input-range": "^0.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/src/components/linted-markdown-editor.ts
+++ b/src/components/linted-markdown-editor.ts
@@ -58,7 +58,6 @@ export abstract class LintedMarkdownEditor extends Component {
     super.disconnect();
 
     this.#resizeObserver.disconnect();
-    this.#rangeRectCalculator.disconnect();
     this.#tooltip.disconnect();
 
     this.#annotationsPortal.remove();

--- a/src/utilities/dom/range-rect-calculator.ts
+++ b/src/utilities/dom/range-rect-calculator.ts
@@ -1,50 +1,6 @@
+import {InputRange} from "textarea-range";
 import {NumberRange} from "../geometry/number-range";
 import {Rect} from "../geometry/rect";
-import {Vector} from "../geometry/vector";
-
-// Note that some browsers, such as Firefox, do not concatenate properties
-// into their shorthand (e.g. padding-top, padding-bottom etc. -> padding),
-// so we have to list every single property explicitly.
-const propertiesToCopy = [
-  "direction", // RTL support
-  "boxSizing",
-  "width", // on Chrome and IE, exclude the scrollbar, so the mirror div wraps exactly as the textarea does
-  "height",
-  "overflowX",
-  "overflowY", // copy the scrollbar for IE
-
-  "borderTopWidth",
-  "borderRightWidth",
-  "borderBottomWidth",
-  "borderLeftWidth",
-  "borderStyle",
-
-  "paddingTop",
-  "paddingRight",
-  "paddingBottom",
-  "paddingLeft",
-
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/font
-  "fontStyle",
-  "fontVariant",
-  "fontWeight",
-  "fontStretch",
-  "fontSize",
-  "fontSizeAdjust",
-  "lineHeight",
-  "fontFamily",
-
-  "textAlign",
-  "textTransform",
-  "textIndent",
-  "textDecoration", // might not make a difference, but better be safe
-
-  "letterSpacing",
-  "wordSpacing",
-
-  "tabSize",
-  "MozTabSize" as "tabSize", // prefixed version for Firefox <= 52
-] as const satisfies ReadonlyArray<keyof CSSStyleDeclaration>;
 
 export interface RangeRectCalculator {
   /**
@@ -62,31 +18,10 @@ export interface RangeRectCalculator {
  * APIs.
  */
 export class TextareaRangeRectCalculator implements RangeRectCalculator {
-  readonly #element: HTMLTextAreaElement;
-  readonly #div: HTMLDivElement;
-  readonly #mutationObserver: MutationObserver;
-  readonly #resizeObserver: ResizeObserver;
-  readonly #range: Range;
+  readonly #range: InputRange;
 
   constructor(target: HTMLTextAreaElement) {
-    this.#element = target;
-
-    // The mirror div will replicate the textarea's style
-    const div = document.createElement("div");
-    this.#div = div;
-    document.body.appendChild(div);
-
-    this.#refreshStyles();
-
-    this.#mutationObserver = new MutationObserver(() => this.#refreshStyles());
-    this.#mutationObserver.observe(this.#element, {
-      attributeFilter: ["style"],
-    });
-
-    this.#resizeObserver = new ResizeObserver(() => this.#refreshStyles());
-    this.#resizeObserver.observe(this.#element);
-
-    this.#range = document.createRange();
+    this.#range = new InputRange(target, 0);
   }
 
   /**
@@ -95,91 +30,12 @@ export class TextareaRangeRectCalculator implements RangeRectCalculator {
    * end char.
    */
   getClientRects({start, end}: NumberRange) {
-    this.#refreshText();
-
-    const textNode = this.#div.childNodes[0];
-    if (!textNode) return [];
-
-    this.#range.setStart(textNode, start);
-    this.#range.setEnd(textNode, end);
-
-    // The div is not in the same place as the textarea so we need to subtract the div
-    // position and add the textarea position
-    const divPosition = new Rect(this.#div.getBoundingClientRect()).asVector();
-    const textareaPosition = new Rect(
-      this.#element.getBoundingClientRect()
-    ).asVector();
-
-    // The div is not scrollable so it does not have scroll adjustment built in
-    const scrollOffset = new Vector(
-      this.#element.scrollLeft,
-      this.#element.scrollTop
-    );
-
-    const netTranslate = divPosition
-      .negate()
-      .plus(textareaPosition)
-      .minus(scrollOffset);
-
-    return Array.from(this.#range.getClientRects()).map((domRect) =>
-      new Rect(domRect).translate(netTranslate)
-    );
+    this.#range.startOffset = start;
+    this.#range.endOffset = end;
+    return this.#range.getClientRects().map((domRect) => new Rect(domRect));
   }
 
-  disconnect() {
-    this.#div.remove();
-  }
-
-  #refreshStyles() {
-    const style = this.#div.style;
-    const textareaStyle = window.getComputedStyle(this.#element);
-
-    // Default wrapping styles
-    style.whiteSpace = "pre-wrap";
-    style.wordWrap = "break-word";
-
-    // Position off-screen
-    style.position = "fixed";
-    style.top = "0";
-    style.transform = "translateY(-100%)";
-
-    const isFirefox = "mozInnerScreenX" in window;
-
-    // Transfer the element's properties to the div
-    for (const prop of propertiesToCopy)
-      if (prop === "width" && textareaStyle.boxSizing === "border-box") {
-        // With box-sizing: border-box we need to offset the size slightly inwards.  This small difference can compound
-        // greatly in long textareas with lots of wrapping, leading to very innacurate results if not accounted for.
-        // Firefox will return computed styles in floats, like `0.9px`, while chromium might return `1px` for the same element.
-        // Either way we use `parseFloat` to turn `0.9px` into `0.9` and `1px` into `1`
-        const totalBorderWidth =
-          parseFloat(textareaStyle.borderLeftWidth) +
-          parseFloat(textareaStyle.borderRightWidth);
-        // When a vertical scrollbar is present it shrinks the content. We need to account for this by using clientWidth
-        // instead of width in everything but Firefox. When we do that we also have to account for the border width.
-        const width = isFirefox
-          ? parseFloat(textareaStyle.width) - totalBorderWidth
-          : this.#element.clientWidth + totalBorderWidth;
-        style.width = `${width}px`;
-      } else {
-        style[prop] = textareaStyle[prop];
-      }
-
-    if (isFirefox) {
-      // Firefox lies about the overflow property for textareas: https://bugzilla.mozilla.org/show_bug.cgi?id=984275
-      if (this.#element.scrollHeight > parseInt(textareaStyle.height))
-        style.overflowY = "scroll";
-    } else {
-      style.overflow = "hidden"; // for Chrome to not render a scrollbar; IE keeps overflowY = 'scroll'
-    }
-  }
-
-  #refreshText() {
-    this.#div.textContent =
-      this.#element instanceof HTMLInputElement
-        ? this.#element.value.replace(/\s/g, "\u00a0")
-        : this.#element.value;
-  }
+  disconnect() {}
 }
 
 export class CodeMirrorRangeRectCalculator implements RangeRectCalculator {

--- a/src/utilities/dom/range-rect-calculator.ts
+++ b/src/utilities/dom/range-rect-calculator.ts
@@ -9,33 +9,20 @@ export interface RangeRectCalculator {
    * exclude the end char.
    */
   getClientRects({start, end}: NumberRange): Rect[];
-  disconnect(): void;
 }
 
-/**
- * The `Range` API doesn't work well with `textarea` elements, so this creates a duplicate
- * element and uses that instead. Provides a limited API wrapping around adjusted `Range`
- * APIs.
- */
 export class TextareaRangeRectCalculator implements RangeRectCalculator {
-  readonly #range: InputRange;
+  readonly #element: HTMLTextAreaElement;
 
   constructor(target: HTMLTextAreaElement) {
-    this.#range = new InputRange(target, 0);
+    this.#element = target;
   }
 
-  /**
-   * Return the viewport-relative client rects of the range. If the range has any line
-   * breaks, this will return multiple rects. Will include the start char and exclude the
-   * end char.
-   */
   getClientRects({start, end}: NumberRange) {
-    this.#range.startOffset = start;
-    this.#range.endOffset = end;
-    return this.#range.getClientRects().map((domRect) => new Rect(domRect));
+    return new InputRange(this.#element, start, end)
+      .getClientRects()
+      .map((domRect) => new Rect(domRect));
   }
-
-  disconnect() {}
 }
 
 export class CodeMirrorRangeRectCalculator implements RangeRectCalculator {
@@ -78,8 +65,6 @@ export class CodeMirrorRangeRectCalculator implements RangeRectCalculator {
       (domRect) => new Rect(domRect)
     );
   }
-
-  disconnect(): void {}
 
   static #getAllTextNodes(node: Node): Node[] {
     const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);

--- a/src/utilities/dom/range-rect-calculator.ts
+++ b/src/utilities/dom/range-rect-calculator.ts
@@ -1,4 +1,4 @@
-import {InputRange} from "textarea-range";
+import {InputRange} from "dom-input-range";
 import {NumberRange} from "../geometry/number-range";
 import {Rect} from "../geometry/rect";
 


### PR DESCRIPTION
I've extracted the code for the rect calculation to https://github.com/iansan5653/dom-input-range. This removes that code and switches to that library.