### PR TITLE
Update `markdownlint-github` and enable `no-empty-alt-text` rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "@github/markdownlint-github": "^0.4.1",
+        "@github/markdownlint-github": "^0.5.0",
         "dom-input-range": "^1.0.3",
         "markdownlint": "^0.31.1"
       },
@@ -1889,9 +1889,9 @@
       }
     },
     "node_modules/@github/markdownlint-github": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@github/markdownlint-github/-/markdownlint-github-0.4.1.tgz",
-      "integrity": "sha512-KbcDWoPRGzlc/VnvPjRD8AhhEFvpQxUbj2NqTPagdoXLVcCc0ecUXLDM3KctIFIuR3OWEQ/+jlDzdeIGb2qEtA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@github/markdownlint-github/-/markdownlint-github-0.5.0.tgz",
+      "integrity": "sha512-m8a7xklDJv8+C5hpaeYE2Jb0IEBwT7fwZpEH3uhYmlcpggRoo0kcnfedB0vUkPfM6Ip7AZgoC3G1SwS/ihadZQ==",
       "dependencies": {
         "lodash": "^4.17.15"
       }
@@ -10377,9 +10377,9 @@
       "dev": true
     },
     "@github/markdownlint-github": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@github/markdownlint-github/-/markdownlint-github-0.4.1.tgz",
-      "integrity": "sha512-KbcDWoPRGzlc/VnvPjRD8AhhEFvpQxUbj2NqTPagdoXLVcCc0ecUXLDM3KctIFIuR3OWEQ/+jlDzdeIGb2qEtA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@github/markdownlint-github/-/markdownlint-github-0.5.0.tgz",
+      "integrity": "sha512-m8a7xklDJv8+C5hpaeYE2Jb0IEBwT7fwZpEH3uhYmlcpggRoo0kcnfedB0vUkPfM6Ip7AZgoC3G1SwS/ihadZQ==",
       "requires": {
         "lodash": "^4.17.15"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@github/markdownlint-github": "^0.4.1",
+    "@github/markdownlint-github": "^0.5.0",
     "markdownlint": "^0.31.1",
     "dom-input-range": "^1.0.3"
   },

--- a/src/utilities/lint-markdown.ts
+++ b/src/utilities/lint-markdown.ts
@@ -19,6 +19,7 @@ export const lintMarkdown = (markdown: string): LintError[] =>
         // easier to read with a screen reader, this rule is ultimately too opinionated and noisy to be worth it,
         // especially because it conflicts with the editor's bulleted list toolbar button.
         "ul-style": false,
+        "no-empty-alt-text": true,
       }),
       handleRuleFailures: true,
       customRules: markdownlintGitHub,
@@ -43,4 +44,6 @@ export const ruleJustifications: Partial<Record<string, string>> = {
     "Using headers to separate sections helps readers use accessibility tools to navigate documents.",
   "ol-prefix":
     "When reading Markdown source code, out-of-order lists make it more difficult for non-sighted users to understand how long a list is.",
+  "no-empty-alt-text":
+    "Images get wrapped in links on github.com, which can result in an inaccessible link with an empty label if the image has empty alt text.",
 };


### PR DESCRIPTION
- Update `markdownlint-github` to `0.5.0`
- Enable [`no-empty-alt-text`](https://github.com/github/markdownlint-github/blob/main/docs/rules/GH003-no-empty-alt-text.md) rule
