### PR TITLE
no age shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,11 +13,11 @@
     "128": "assets/icon-128.png"
   },
   "homepage_url": "https://github.com/iansan5653/markdown-a11y-extension",
-  "minimum_chrome_version": "112",
+  "minimum_chrome_version": "1",
   "browser_specific_settings": {
     "gecko": {
       "id": "markdown-a11y-checker@iansan5653",
-      "strict_min_version": "112.0"
+      "strict_min_version": "1"
     }
   }
 }


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 112 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 112+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)