### PR TITLE
Update `dom-input-range` to fix Firefox bugs and improve performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@github/markdownlint-github": "^0.6.0",
-        "dom-input-range": "^1.0.3",
+        "dom-input-range": "^1.1.0",
         "markdownlint": "^0.33.0"
       },
       "devDependencies": {
@@ -3893,9 +3893,9 @@
       }
     },
     "node_modules/dom-input-range": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.0.3.tgz",
-      "integrity": "sha512-kiBk4Bf/ff5mwW8nRvvYMGOYsFq4VAsyGb/CiW2Fq67dHQnKFgz0LDMJk1oiE+VUojI/woTxE6fnMoo4sJ054g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.1.0.tgz",
+      "integrity": "sha512-qO3wWMP539+uwDEuxkzpgGKC2TR85uVmjLB7IYGiTke+uL1qleKy/gzO26SsdTFnF8010VFVekChGEpme5iPTA=="
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -11872,9 +11872,9 @@
       }
     },
     "dom-input-range": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.0.3.tgz",
-      "integrity": "sha512-kiBk4Bf/ff5mwW8nRvvYMGOYsFq4VAsyGb/CiW2Fq67dHQnKFgz0LDMJk1oiE+VUojI/woTxE6fnMoo4sJ054g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.1.0.tgz",
+      "integrity": "sha512-qO3wWMP539+uwDEuxkzpgGKC2TR85uVmjLB7IYGiTke+uL1qleKy/gzO26SsdTFnF8010VFVekChGEpme5iPTA=="
     },
     "dom-serializer": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@github/markdownlint-github": "^0.6.0",
     "markdownlint": "^0.33.0",
-    "dom-input-range": "^1.1.0"
+    "dom-input-range": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@github/markdownlint-github": "^0.6.0",
     "markdownlint": "^0.33.0",
-    "dom-input-range": "^1.0.3"
+    "dom-input-range": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",


### PR DESCRIPTION
Updates `dom-input-range` to [`v1.1.1`](https://github.com/iansan5653/dom-input-range/releases/tag/1.1.1), which includes [`v1.1.0`](https://github.com/iansan5653/dom-input-range/releases/tag/1.1.0).