### PR TITLE
Add polyfill for custom elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@github/markdownlint-github": "^0.6.0",
+        "@webcomponents/custom-elements": "^1.6.0",
         "dom-input-range": "^1.1.1",
         "markdownlint": "^0.33.0"
       },
@@ -2297,6 +2298,11 @@
         "@webassemblyjs/ast": "1.11.5",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webcomponents/custom-elements": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.6.0.tgz",
+      "integrity": "sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww=="
     },
     "node_modules/@webpack-cli/configtest": {
       "version": "2.0.1",
@@ -10720,6 +10726,11 @@
         "@webassemblyjs/ast": "1.11.5",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@webcomponents/custom-elements": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.6.0.tgz",
+      "integrity": "sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww=="
     },
     "@webpack-cli/configtest": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
   "license": "MIT",
   "dependencies": {
     "@github/markdownlint-github": "^0.6.0",
-    "markdownlint": "^0.33.0",
-    "dom-input-range": "^1.1.1"
+    "@webcomponents/custom-elements": "^1.6.0",
+    "dom-input-range": "^1.1.1",
+    "markdownlint": "^0.33.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",
@@ -24,8 +25,8 @@
     "prettier": "^2.8.8",
     "ts-loader": "^9.4.3",
     "typescript": "^5.0.4",
+    "web-ext": "^7.6.2",
     "webpack": "^5.83.1",
-    "webpack-cli": "^5.0.1",
-    "web-ext": "^7.6.2"
+    "webpack-cli": "^5.0.1"
   }
 }

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -1,3 +1,5 @@
+import '@webcomponents/custom-elements'
+
 import {
   LintedMarkdownCodeMirrorEditor,
   LintedMarkdownTextareaEditor,

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -1,4 +1,4 @@
-import '@webcomponents/custom-elements'
+import "@webcomponents/custom-elements";
 
 import {
   LintedMarkdownCodeMirrorEditor,


### PR DESCRIPTION
Currently the extension is failing everywhere due to a failure to register the custom element required for it to operate. Custom element registration is not supported in content scripts and must be polyfilled.