### PR TITLE
Fix race conditions causing flickering while typing

### DIFF
--- a/src/components/linted-markdown-editor.ts
+++ b/src/components/linted-markdown-editor.ts
@@ -181,8 +181,10 @@ export abstract class LintedMarkdownEditor extends Component {
   }
 
   #recalculateAnnotationPositions() {
-    for (const annotation of this.#annotations)
-      annotation.recalculatePosition();
+    requestAnimationFrame(() => {
+      for (const annotation of this.#annotations)
+        annotation.recalculatePosition();
+    });
   }
 
   #updatePointerTooltip(pointerLocation: Vector) {

--- a/src/components/linted-markdown-editor.ts
+++ b/src/components/linted-markdown-editor.ts
@@ -16,6 +16,7 @@ export abstract class LintedMarkdownEditor extends Component {
   #tooltip: LintErrorTooltip;
   #resizeObserver: ResizeObserver;
   #rangeRectCalculator: RangeRectCalculator;
+  #isTyping = false;
 
   #annotationsPortal = document.createElement("div");
   #statusContainer = LintedMarkdownEditor.#createStatusContainerElement();
@@ -124,7 +125,11 @@ export abstract class LintedMarkdownEditor extends Component {
     else this.#tooltip.hide();
   }
 
-  protected onUpdate = () => this.#lint();
+  protected onUpdate = () => {
+    this.#isTyping = true;
+    setTimeout(() => (this.#isTyping = false), 10);
+    this.#lint();
+  };
 
   #isOnRepositionTick = false;
   #onReposition = () => {
@@ -146,7 +151,8 @@ export abstract class LintedMarkdownEditor extends Component {
 
   #onSelectionChange = () => {
     // this event only works when applied to the document but we can filter it by detecting focus
-    if (document.activeElement === this.#editor) this.#updateCaretTooltip();
+    if (!this.#isTyping && document.activeElement === this.#editor)
+      this.#updateCaretTooltip();
   };
 
   #clear() {


### PR DESCRIPTION
- Fixes a bug where the tooltip would flicker as you type, by updating the `selectionchange` event to only run if the input hasn't changed in the last 10ms
- Fixes a bug where the lint annotations would end up in the wrong position occasionally when you type, by running the update logic in a `requestAnimationFrame` (I should eventually just update `dom-input-range` to flush synchronously when the user is typing, rather than requesting animation frames, which should only be done on scroll)